### PR TITLE
publish to crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # alpm
 
 A lib for managing packages in arch linux.
+
+This fork compiles on stable rust: [https://crates.io/crates/libalpm-fork](https://crates.io/crates/libalpm-fork)
+
+The code is taken from here: https://github.com/jameslzhu/alpm  and published.
+Unfortunately, the real author of the code didn't publish it.
+
+Hopefully it'll be resolved over time and "jameslzhu" will publishe their code themselves.

--- a/alpm-sys/Cargo.toml
+++ b/alpm-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "alpm-sys"
+name = "alpm-sys-fork"
 version = "0.1.2"
 repository = "https://github.com/derekdreery/alpm-sys"
 documentation = "https://docs.rs/alpm-sys/"

--- a/libalpm-utils/Cargo.toml
+++ b/libalpm-utils/Cargo.toml
@@ -11,4 +11,4 @@ A library for helpful additions to libalpm not from the C library
 
 [dependencies]
 nom = "^2.0"
-libalpm = { path = "../libalpm" }
+libalpm-fork = { path = "../libalpm" }

--- a/libalpm/Cargo.toml
+++ b/libalpm/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
-name = "libalpm"
+name = "libalpm-fork"
 version = "0.1.3"
-authors = ["Richard Dodd <richard.o.dodd@gmail.com>"]
+authors = ["James Zhu", "Richard Dodd <richard.o.dodd@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/derekdreery/alpm"
-homepage = "https://github.com/derekdreery/alpm/tree/master/libalpm"
+repository = "https://github.com/vn971/alpm"
+homepage = "https://github.com/vn971/alpm/tree/master/libalpm"
 documentation = "https://derekdreery.github.io/alpm/libalpm/index.html"
 description = """
 An aspirationally safe wrapper around libalpm (the Arch Linux Package Manager).
+This fork compiles on stable rust.
 """
 
 [dependencies]
-alpm-sys = { git = "https://github.com/jameslzhu/alpm", branch = "master" }
+alpm-sys-fork = { path = "../alpm-sys", version = "0.1.2" }
 printf = "0.1"
 libc = "0.2"
 url = "1.4"

--- a/libalpm/README.md
+++ b/libalpm/README.md
@@ -1,5 +1,14 @@
 # libalpm (A wrapper round libalpm, the Arch Linux Package Manager)
 
+This fork compiles on stable rust: [https://crates.io/crates/libalpm-fork](https://crates.io/crates/libalpm-fork)
+
+The code is taken from here: https://github.com/jameslzhu/alpm  and published.
+Unfortunately, the real author of the code didn't publish it.
+
+Hopefully it'll be resolved over time and "jameslzhu" will publishe their code themselves.
+
+----
+
 I've changed some function names to match rust convention (e.g. no 'get',
 `get_value() => value()`, no shortened words `desc => description`).
 

--- a/libalpm/src/callbacks.rs
+++ b/libalpm/src/callbacks.rs
@@ -2,7 +2,7 @@ use std::panic;
 use std::ffi::CStr;
 
 use printf::printf;
-use alpm_sys::*;
+use alpm_sys_fork::*;
 use libc::{c_int, c_char, c_void, off_t};
 
 use {LOG_CB, DOWNLOAD_CB, DLTOTAL_CB, FETCH_CB, EVENT_CB, DownloadResult};

--- a/libalpm/src/db.rs
+++ b/libalpm/src/db.rs
@@ -2,7 +2,7 @@ use std::ffi::{CStr, CString};
 use std::str::Utf8Error;
 use std::mem;
 
-use alpm_sys::*;
+use alpm_sys_fork::*;
 use pgp::SigLevel;
 use libc::{c_char};
 
@@ -270,7 +270,7 @@ impl Default for Usage {
 
 impl From<Usage> for u32 {
     fn from(from: Usage) -> Self {
-        use alpm_sys::alpm_db_usage_t::*;
+        use alpm_sys_fork::alpm_db_usage_t::*;
         let mut acc = 0;
         if from.sync {
             acc |= ALPM_DB_USAGE_SYNC as u32;
@@ -290,7 +290,7 @@ impl From<Usage> for u32 {
 
 impl From<u32> for Usage {
     fn from(from: u32) -> Self {
-        use alpm_sys::alpm_db_usage_t::*;
+        use alpm_sys_fork::alpm_db_usage_t::*;
         Usage {
             sync: from & ALPM_DB_USAGE_SYNC as u32 != 0,
             search: from & ALPM_DB_USAGE_SEARCH as u32 != 0,

--- a/libalpm/src/error.rs
+++ b/libalpm/src/error.rs
@@ -294,7 +294,7 @@ pub type AlpmResult<T> = Result<T, Error>;
 #[cfg(test)]
 mod test {
     use super::*;
-    extern crate alpm_sys;
+    extern crate alpm_sys_fork;
 
     #[test]
     fn from_u32() {

--- a/libalpm/src/error.rs
+++ b/libalpm/src/error.rs
@@ -204,7 +204,7 @@ impl fmt::Display for Error {
 
 impl From<u32> for Error {
     fn from(from: u32) -> Error {
-        use alpm_sys::alpm_errno_t::*;
+        use alpm_sys_fork::alpm_errno_t::*;
         match from {
             x if x == ALPM_ERR_MEMORY as u32 => Error::Memory,
             x if x == ALPM_ERR_SYSTEM as u32 => Error::System,
@@ -298,7 +298,7 @@ mod test {
 
     #[test]
     fn from_u32() {
-        let err = alpm_sys::alpm_errno_t::ALPM_ERR_MEMORY as u32;
+        let err = alpm_sys_fork::alpm_errno_t::ALPM_ERR_MEMORY as u32;
         assert_eq!(Error::Memory, err.into());
     }
 }

--- a/libalpm/src/event.rs
+++ b/libalpm/src/event.rs
@@ -1,6 +1,6 @@
 //! Utility types/fn for `alpm_event_t`
 
-use alpm_sys::*;
+use alpm_sys_fork::*;
 
 use package::PackageOperation;
 

--- a/libalpm/src/lib.rs
+++ b/libalpm/src/lib.rs
@@ -14,7 +14,7 @@
 //! let alpm = Alpm::new("/", "/var/lib/pacman"); // default locations on arch linux
 //! ```
 
-extern crate alpm_sys;
+extern crate alpm_sys_fork;
 extern crate chrono;
 #[macro_use]
 extern crate lazy_static;

--- a/libalpm/src/lib.rs
+++ b/libalpm/src/lib.rs
@@ -41,7 +41,7 @@ use std::sync::Mutex;
 use std::ptr;
 use std::marker::PhantomData;
 
-use alpm_sys::*;
+use alpm_sys_fork::*;
 use libc::{c_char, c_void};
 
 pub use options::{Config, RepoConfig};
@@ -619,7 +619,7 @@ impl Alpm {
             let raw_list = alpm_get_syncdbs(self.handle);
             //println!("{:?}", raw_list);
             //println!("error: {:?}", self.error().unwrap().description());
-            util::alpm_list_to_vec(raw_list, |ptr| Db::new(ptr as *mut alpm_sys::alpm_db_t, self))
+            util::alpm_list_to_vec(raw_list, |ptr| Db::new(ptr as *mut alpm_sys_fork::alpm_db_t, self))
         }
     }
 

--- a/libalpm/src/log.rs
+++ b/libalpm/src/log.rs
@@ -4,7 +4,7 @@ use std::default::Default;
 use std::fmt;
 use std::cmp::{self, Ordering};
 
-use alpm_sys::*;
+use alpm_sys_fork::*;
 
 /// The highest log level marked true
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -116,7 +116,7 @@ impl LogLevels {
 
 impl Into<u32> for LogLevels {
     fn into(self) -> u32 {
-        use alpm_sys::alpm_loglevel_t::*;
+        use alpm_sys_fork::alpm_loglevel_t::*;
         let mut acc = 0;
         if self.error {
             acc |= ALPM_LOG_ERROR as u32;

--- a/libalpm/src/package.rs
+++ b/libalpm/src/package.rs
@@ -1,5 +1,5 @@
 
-use alpm_sys::*;
+use alpm_sys_fork::*;
 use libc::{self, c_char, c_ulong};
 use chrono::{NaiveDateTime, NaiveDate};
 
@@ -607,7 +607,7 @@ pub enum PackageFrom {
 
 impl Into<u32> for PackageFrom {
     fn into(self) -> u32 {
-        use alpm_sys::alpm_pkgfrom_t::*;
+        use alpm_sys_fork::alpm_pkgfrom_t::*;
         match self {
             PackageFrom::File => ALPM_PKG_FROM_FILE as u32,
             PackageFrom::LocalDb => ALPM_PKG_FROM_LOCALDB as u32,
@@ -640,7 +640,7 @@ pub enum Reason {
 
 impl Into<u32> for Reason {
     fn into(self) -> u32 {
-        use alpm_sys::alpm_pkgreason_t::*;
+        use alpm_sys_fork::alpm_pkgreason_t::*;
         match self {
             Reason::Explicit => ALPM_PKG_REASON_EXPLICIT as u32,
             Reason::Depend => ALPM_PKG_REASON_DEPEND as u32,
@@ -650,7 +650,7 @@ impl Into<u32> for Reason {
 
 impl From<u32> for Reason {
     fn from(f: u32) -> Self {
-        use alpm_sys::alpm_pkgreason_t::*;
+        use alpm_sys_fork::alpm_pkgreason_t::*;
         if f == ALPM_PKG_REASON_EXPLICIT as u32 {
             Reason::Explicit
         } else if f == ALPM_PKG_REASON_DEPEND as u32 {
@@ -663,7 +663,7 @@ impl From<u32> for Reason {
 
 impl From<Reason> for alpm_pkgreason_t {
     fn from(from: Reason) -> Self {
-        use alpm_sys::alpm_pkgreason_t::*;
+        use alpm_sys_fork::alpm_pkgreason_t::*;
         match from {
             Reason::Explicit => ALPM_PKG_REASON_EXPLICIT,
             Reason::Depend => ALPM_PKG_REASON_DEPEND,
@@ -742,7 +742,7 @@ impl Validation {
 
 impl From<Validation> for u32 {
     fn from(from: Validation) -> Self {
-        use alpm_sys::alpm_pkgvalidation_t::*;
+        use alpm_sys_fork::alpm_pkgvalidation_t::*;
         match from {
             Validation::Unknown => ALPM_PKG_VALIDATION_UNKNOWN as u32,
             Validation::None => ALPM_PKG_VALIDATION_NONE as u32,

--- a/libalpm/src/pgp.rs
+++ b/libalpm/src/pgp.rs
@@ -36,7 +36,7 @@ impl From<SigLevel> for u32 {
 
 impl<'a> From<&'a SigLevel> for u32 {
     fn from(from: &'a SigLevel) -> u32 {
-        use alpm_sys::alpm_siglevel_t::*;
+        use alpm_sys_fork::alpm_siglevel_t::*;
         let mut acc = 0;
         if from.package {
             acc |= ALPM_SIG_PACKAGE as u32;

--- a/libalpm/src/trans.rs
+++ b/libalpm/src/trans.rs
@@ -5,7 +5,7 @@ use std::ptr;
 use std::mem;
 use std::marker::PhantomData;
 
-use alpm_sys::*;
+use alpm_sys_fork::*;
 use super::{Alpm, Package, PackageRef, Error, AlpmResult, util};
 use libc;
 

--- a/libalpm/src/types.rs
+++ b/libalpm/src/types.rs
@@ -1,6 +1,6 @@
 //! A place for types related to alpm, rather than e.g. a package
 
-use alpm_sys::*;
+use alpm_sys_fork::*;
 
 /// This version of libalpm's capabilities
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/libalpm/src/util.rs
+++ b/libalpm/src/util.rs
@@ -4,7 +4,7 @@ use libc;
 use std::mem;
 use std::ptr;
 use std::ffi::{CStr, CString};
-use alpm_sys::*;
+use alpm_sys_fork::*;
 
 /// A wrapper around a `libc::utsname` struct, holding information on the current computer and os.
 pub struct UtsName(libc::utsname);


### PR DESCRIPTION
Can you please publish your fork on crates.io? The current libalpm doesn't build on stable rust.

I've published your version under the name of `libalpm-fork` and `alpm-sys-fork` as a temporary work-around. I'd be glad to give "owner" status for you for these packages (including to remove me as owner), or you might create your own packages if you wish.

The diff in this pull request shows the approximate changes one has to take to publish to crates.io. Thoughts?

P.S. Also, sadly, the original project had issues page closed, and your fork seems to inherit that. Could be a good idea to change that if you like.

Thanks for your fork!